### PR TITLE
Change ivy path to valid archive location on apache.org

### DIFF
--- a/grails/build.xml
+++ b/grails/build.xml
@@ -16,7 +16,7 @@
 	<target name="-download-ivy" unless="ivy.available">
         <mkdir dir="${ivy.jar.dir}"/>
         <!-- download Ivy from web site so that it can be used even without any special installation -->
-        <get src="http://www.apache.org/dist/ant/ivy/${ivy.install.version}/apache-ivy-${ivy.install.version}-bin.zip"
+        <get src="http://archive.apache.org/dist/ant/ivy/${ivy.install.version}/apache-ivy-${ivy.install.version}-bin.zip"
             dest="${ivy.home}/ivy.zip" usetimestamp="true" verbose="true"/>
 	    <unzip src="${ivy.home}/ivy.zip" dest="${ivy.jar.dir}">
 		   <patternset>


### PR DESCRIPTION
The http://www.apache.org/dist repo only holds the latest version of ivy. Changing this to archive.apache.org allows all versions to be used.
